### PR TITLE
phoneme_guesser

### DIFF
--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -7,6 +7,8 @@ import json
 MYCROFT_SYSTEM_CONFIG = "/etc/mycroft/mycroft.conf"
 MYCROFT_USER_CONFIG = join(expanduser("~"), ".mycroft", "mycroft.conf")
 
+# TODO use json_database
+
 
 class LocalConf(dict):
     """

--- a/ovos_utils/enclosure.py
+++ b/ovos_utils/enclosure.py
@@ -1,5 +1,4 @@
 import time
-import socket
 from ovos_utils.log import LOG
 from ovos_utils.messagebus import Message, get_mycroft_bus
 

--- a/ovos_utils/lang/phonemes.py
+++ b/ovos_utils/lang/phonemes.py
@@ -1,84 +1,15 @@
-import pronouncing
+from phoneme_guesser import guess_phonemes as _guess_phonemes, \
+    get_phonemes as _get_phonemes
+
+# Backwards compat, TODO deprecate?
 
 
-def guess_phonemes(word):
-    word = word.lower()
-    basic_pronunciations = {'a': ['AE'], 'b': ['B'], 'c': ['K'],
-                           'd': ['D'],
-                           'e': ['EH'], 'f': ['F'], 'g': ['G'],
-                           'h': ['HH'],
-                           'i': ['IH'],
-                           'j': ['JH'], 'k': ['K'], 'l': ['L'],
-                           'm': ['M'],
-                           'n': ['N'], 'o': ['OW'], 'p': ['P'],
-                           'qu': ['K', 'W'], 'r': ['R'],
-                           's': ['S'], 't': ['T'], 'u': ['AH'],
-                           'v': ['V'],
-                           'w': ['W'], 'x': ['K', 'S'], 'y': ['Y'],
-                           'z': ['Z'], 'ch': ['CH'],
-                           'sh': ['SH'], 'th': ['TH'], 'dg': ['JH'],
-                           'dge': ['JH'], 'psy': ['S', 'AY'],
-                           'oi': ['OY'],
-                           'ee': ['IY'],
-                           'ao': ['AW'], 'ck': ['K'], 'tt': ['T'],
-                           'nn': ['N'], 'ai': ['EY'], 'eu': ['Y', 'UW'],
-                           'ue': ['UW'],
-                           'ie': ['IY'], 'ei': ['IY'], 'ea': ['IY'],
-                           'ght': ['T'], 'ph': ['F'], 'gn': ['N'],
-                           'kn': ['N'], 'wh': ['W'],
-                           'wr': ['R'], 'gg': ['G'], 'ff': ['F'],
-                           'oo': ['UW'], 'ua': ['W', 'AO'], 'ng': ['NG'],
-                           'bb': ['B'],
-                           'tch': ['CH'], 'rr': ['R'], 'dd': ['D'],
-                           'cc': ['K', 'S'], 'oe': ['OW'],
-                           'igh': ['AY'], 'eigh': ['EY']}
-    phones = []
-
-    progress = len(word) - 1
-    while progress >= 0:
-        if word[0:3] in basic_pronunciations.keys():
-            for phone in basic_pronunciations[word[0:3]]:
-                phones.append(phone)
-            word = word[3:]
-            progress -= 3
-        elif word[0:2] in basic_pronunciations.keys():
-            for phone in basic_pronunciations[word[0:2]]:
-                phones.append(phone)
-            word = word[2:]
-            progress -= 2
-        elif word[0] in basic_pronunciations.keys():
-            for phone in basic_pronunciations[word[0]]:
-                phones.append(phone)
-            word = word[1:]
-            progress -= 1
-        else:
-            return None
-    return phones
+def guess_phonemes(word, lang="en-us"):
+    return _guess_phonemes(word, lang)
 
 
-def get_phonemes(name):
-    name = name.lower()
-    phonemes = None
-    if " " in name:
-        total_phonemes = []
-        names = name.split(" ")
-        for name in names:
-            phon = get_phonemes(name)
-            if phon is None:
-                return None
-            total_phonemes.extend(phon)
-            total_phonemes.append(" . ")
-        if total_phonemes[-1] == " . ":
-            total_phonemes = total_phonemes[:-1]
-        phonemes = "".join(total_phonemes)
-    elif len(pronouncing.phones_for_word(name)):
-        phonemes = "".join(pronouncing.phones_for_word(name)[0])
-    else:
-        guess = guess_phonemes(name)
-        if guess is not None:
-            phonemes = " ".join(guess)
-
-    return phonemes
+def get_phonemes(name, lang="en-us"):
+    return _get_phonemes(name, lang)
 
 
 if __name__ == "__main__":

--- a/ovos_utils/misc/markov.py
+++ b/ovos_utils/misc/markov.py
@@ -1,6 +1,3 @@
-START_OF_SEQ = "~"
-END_OF_SEQ = "[END]"
-
 import random
 import json
 
@@ -9,6 +6,8 @@ class MarkovChain:
     """
     Simple Markov Chain Class
     """
+    START_OF_SEQ = "~"
+    END_OF_SEQ = "[END]"
 
     def __init__(self, order=1, pad=True, records=None):
         """
@@ -27,7 +26,8 @@ class MarkovChain:
         :return: None
         """
         if self.pad:
-            tokens = [START_OF_SEQ] * self.order + tokens + [END_OF_SEQ]
+            tokens = [self.START_OF_SEQ] * self.order + tokens + [
+                self.END_OF_SEQ]
 
         for i in range(len(tokens) - self.order):
             current_state = tuple(tokens[i:i + self.order])
@@ -73,7 +73,7 @@ class MarkovChain:
             next_token = self.sample(current_state)
             sequence.append(next_token)
 
-            if next_token == END_OF_SEQ:
+            if next_token == self.END_OF_SEQ:
                 return sequence
 
         return sequence

--- a/ovos_utils/security.py
+++ b/ovos_utils/security.py
@@ -1,8 +1,9 @@
-import platform, os
+import platform
 import pexpect
 from socket import gethostname
 from os.path import exists, join
 from os import makedirs
+import os
 import random
 import string
 from ovos_utils.log import LOG

--- a/ovos_utils/skills/intent_provider.py
+++ b/ovos_utils/skills/intent_provider.py
@@ -25,7 +25,7 @@ class IntentEngineSkill(FallbackSkill):
         FallbackSkill.__init__(self)
         self.engine = None
         self.config = {}
-        self.priority = 4
+        self.priority = 1
 
     def initialize(self):
         engine = BaseIntentEngine("dummy")

--- a/ovos_utils/sound/__init__.py
+++ b/ovos_utils/sound/__init__.py
@@ -1,6 +1,7 @@
 import subprocess
 import time
 from ovos_utils.log import LOG
+from ovos_utils.signal import check_for_signal
 
 
 def play_audio(uri, play_cmd="play %1"):

--- a/ovos_utils/ssml.py
+++ b/ovos_utils/ssml.py
@@ -1,7 +1,7 @@
 import re
 
 
-class SSMLBuilder(object):
+class SSMLBuilder:
     def __init__(self, ssml_tag=False, speak_tag=True):
         self.text = ""
         self.ssml_tags = ["speak", "ssml", "phoneme", "voice", "audio", "sub",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pycld2 # optional, needed for lang detection
 pycld3 # optional, needed for lang detection
 google_trans_new # optional, used for lang detection / translation
-pronouncing
+phoneme_guesser
 mycroft-messagebus-client
 colour
 inflection

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from setuptools import setup
 
 setup(
     name='ovos_utils',
-    version='0.0.2',
+    version='0.0.3',
     packages=['ovos_utils',
               'ovos_utils.sound',
               'ovos_utils.mark1',
               'ovos_utils.skills',
               'ovos_utils.lang'],
     url='https://github.com/OpenVoiceOS/ovos_utils',
-    install_requires=["pronouncing",
+    install_requires=["phoneme_guesser",
                       "mycroft-messagebus-client",
                       "inflection",
                       "colour",


### PR DESCRIPTION
# migrate to phoneme_guesser

i had a basic get_phonemes util in this package, however that has grown to include proper language support and is now a standalone package

https://github.com/OpenJarbas/phoneme_guesser

since this will be used by other utilities in this package (wake word related, TTS related) it makes sense to include it as a dependency instead of throwing a deprecation warning

# extra changes

version bumped for a new minor release

minor improvement:
- make the intent_provider fallback skill class higher priority

minor bug fix:
- missing import added

minor cleanups:
- add a TODO to use json_database in the mycroft config utils
- move some global vars to the class level
- cleanup old style classes (derived from object)
- remove unused import