### PR TITLE
enclosure2rootdir - dont throw exception

### DIFF
--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -151,7 +151,8 @@ class MycroftDefaultConfig(ReadOnlyConfig):
                     "configuration", "mycroft.conf")
         super().__init__(path)
         if not self.path or not isfile(self.path):
-            LOG.warning("mycroft root path not found")
+            LOG.error("mycroft root path not found, could not load default "
+                      ".conf")
 
     def set_root_config_path(self, root_config):
         # in case we got it wrong / non standard

--- a/ovos_utils/enclosure/__init__.py
+++ b/ovos_utils/enclosure/__init__.py
@@ -1,4 +1,5 @@
 from ovos_utils.system import MycroftRootLocations
+from ovos_utils.log import LOG
 from enum import Enum
 from os.path import exists
 
@@ -27,7 +28,8 @@ def enclosure2rootdir(enclosure=None):
         return MycroftRootLocations.OVOS
     elif enclosure == MycroftEnclosures.BIGSCREEN:
         return MycroftRootLocations.BIGSCREEN
-    raise EnvironmentError
+    LOG.warning("Assuming mycroft-core location is ~/mycroft-core")
+    return MycroftRootLocations.HOME
 
 
 def detect_enclosure():


### PR DESCRIPTION
in non standard installs (desktop) an exception was thrown when reading default config if it was not detected, we just want to LOG that

reported by @forslund 