### PR TITLE
Find mycroft root from sitepackages

### DIFF
--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -1,7 +1,8 @@
 from ovos_utils.log import LOG
-from ovos_utils.enclosure import enclosure2rootdir, detect_enclosure
+from ovos_utils.enclosure import detect_enclosure
 from ovos_utils.enclosure import MycroftEnclosures
 from ovos_utils.json_helper import merge_dict, load_commented_json
+from ovos_utils.system import search_mycroft_core_location
 from os.path import isfile, exists, expanduser, join, dirname, isdir
 from os import makedirs
 import json
@@ -147,7 +148,10 @@ class MycroftUserConfig(LocalConf):
 
 class MycroftDefaultConfig(ReadOnlyConfig):
     def __init__(self):
-        path = join(enclosure2rootdir(), "mycroft",
+        mycroft_root = search_mycroft_core_location()
+        if not mycroft_root:
+            raise FileNotFoundError("Couldn't find mycroft core root folder.")
+        path = join(mycroft_root, "mycroft",
                     "configuration", "mycroft.conf")
         super().__init__(path)
         if not self.path or not isfile(self.path):

--- a/ovos_utils/enclosure/__init__.py
+++ b/ovos_utils/enclosure/__init__.py
@@ -1,7 +1,7 @@
 from ovos_utils.system import MycroftRootLocations
 from ovos_utils.log import LOG
 from enum import Enum
-from os.path import exists
+from os.path import exists, join
 
 
 class MycroftEnclosures(str, Enum):
@@ -28,6 +28,7 @@ def enclosure2rootdir(enclosure=None):
         return MycroftRootLocations.OVOS
     elif enclosure == MycroftEnclosures.BIGSCREEN:
         return MycroftRootLocations.BIGSCREEN
+
     LOG.warning("Assuming mycroft-core location is ~/mycroft-core")
     return MycroftRootLocations.HOME
 


### PR DESCRIPTION
Uses the sys path setup by the mycroft dev_setup.sh as well as the python environments sitepackages to find the mycroft "root" folder.

Not sure if this should be separated from the enclosure2root, in theory I think it should be able to cover most installs.