### PR TITLE
gui template - confirmation/error status

### DIFF
--- a/ovos_utils/res/ui/SYSTEM_status.qml
+++ b/ovos_utils/res/ui/SYSTEM_status.qml
@@ -1,0 +1,44 @@
+import QtQuick.Layouts 1.4
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import org.kde.kirigami 2.4 as Kirigami
+
+import Mycroft 1.0 as Mycroft
+
+Mycroft.ProportionalDelegate {
+    id: root
+    skillBackgroundColorOverlay: sessionData.bgColor
+    
+    ColumnLayout {
+        id: grid
+        anchors.centerIn: parent
+
+        Image {
+            id: statusIcon
+            visible: true
+            enabled: true
+            anchors.horizontalCenter: grid.horizontalCenter
+            Layout.preferredWidth: proportionalGridUnit * 50
+            Layout.preferredHeight: proportionalGridUnit * 50
+            source: sessionData.icon
+        }
+
+        /* Add some spacing between icon and text */
+        Item {
+            height: Kirigami.Units.largeSpacing
+        }
+
+        Label {
+            id: statusLabel
+            Layout.alignment: Qt.AlignHCenter
+            font.pixelSize: 65
+            wrapMode: Text.WordWrap
+            renderType: Text.NativeRendering
+            font.family: "Noto Sans Display"
+            font.styleName: "Black"
+            font.capitalization: Font.AllUppercase
+            text: sessionData.label
+            color: "white"
+        }
+    }
+}

--- a/ovos_utils/res/ui/icons/check-circle.svg
+++ b/ovos_utils/res/ui/icons/check-circle.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="check-circle.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 512 512">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="255.3616"
+     inkscape:cx="157.36658"
+     inkscape:zoom="1.5664062"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z" />
+</svg>

--- a/ovos_utils/res/ui/icons/info-circle.svg
+++ b/ovos_utils/res/ui/icons/info-circle.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 512 512"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="info-circle.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="724"
+     inkscape:window-height="480"
+     id="namedview6"
+     showgrid="false"
+     inkscape:zoom="0.4609375"
+     inkscape:cx="256"
+     inkscape:cy="256"
+     inkscape:window-x="0"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4" />
+  <path
+     d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 448c-110.532 0-200-89.431-200-200 0-110.495 89.472-200 200-200 110.491 0 200 89.471 200 200 0 110.53-89.431 200-200 200zm0-338c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"
+     id="path2"
+     style="fill:#ffffff" />
+</svg>

--- a/ovos_utils/res/ui/icons/times-circle.svg
+++ b/ovos_utils/res/ui/icons/times-circle.svg
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="times-circle.svg"
+   id="svg4"
+   version="1.1"
+   viewBox="0 0 512 512">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     inkscape:current-layer="svg4"
+     inkscape:window-maximized="1"
+     inkscape:window-y="30"
+     inkscape:window-x="0"
+     inkscape:cy="255.3616"
+     inkscape:cx="157.36658"
+     inkscape:zoom="1.5664062"
+     showgrid="false"
+     id="namedview6"
+     inkscape:window-height="1017"
+     inkscape:window-width="1920"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0"
+     guidetolerance="10"
+     gridtolerance="10"
+     objecttolerance="10"
+     borderopacity="1"
+     bordercolor="#666666"
+     pagecolor="#ffffff" />
+  <path
+     style="fill:#ffffff;fill-opacity:1"
+     id="path2"
+     d="M256 8C119 8 8 119 8 256s111 248 248 248 248-111 248-248S393 8 256 8zm121.6 313.1c4.7 4.7 4.7 12.3 0 17L338 377.6c-4.7 4.7-12.3 4.7-17 0L256 312l-65.1 65.6c-4.7 4.7-12.3 4.7-17 0L134.4 338c-4.7-4.7-4.7-12.3 0-17l65.6-65-65.6-65.1c-4.7-4.7-4.7-12.3 0-17l39.6-39.6c4.7-4.7 12.3-4.7 17 0l65 65.7 65.1-65.6c4.7-4.7 12.3-4.7 17 0l39.6 39.6c4.7 4.7 4.7 12.3 0 17L312 256l65.6 65.1z" />
+</svg>

--- a/ovos_utils/waiting_for_mycroft/skill_gui.py
+++ b/ovos_utils/waiting_for_mycroft/skill_gui.py
@@ -65,6 +65,22 @@ class SkillGUI(_SkillGUI):
         self.__skills_config = {}  # data object passed to skill's page
         self.settings_gui_generator = SettingsGuiGenerator()
 
+    # new gui templates
+    # NOT YET PRed to mycroft-core, taken from gez-mycroft wifi GUI test skill
+    def show_confirmation_status(self, text="", override_idle=False):
+        self.clear()
+        self["icon"] = resolve_ovos_resource_file("ui/icons/check-circle.svg")
+        self["label"] = text
+        self["bgColor"] = "#40DBB0"
+        self.show_page("SYSTEM_status.qml", override_idle=override_idle)
+
+    def show_error_status(self, text="", override_idle=False):
+        self.clear()
+        self["icon"] = resolve_ovos_resource_file("ui/icons/times-circle.svg")
+        self["label"] = text
+        self["bgColor"] = "#FF0000"
+        self.show_page("SYSTEM_status.qml", override_idle=override_idle)
+
     # video playback
     # https://github.com/MycroftAI/mycroft-core/pull/2683
     def setup_default_handlers(self):

--- a/ovos_utils/waiting_for_mycroft/skill_gui.py
+++ b/ovos_utils/waiting_for_mycroft/skill_gui.py
@@ -67,19 +67,23 @@ class SkillGUI(_SkillGUI):
 
     # new gui templates
     # NOT YET PRed to mycroft-core, taken from gez-mycroft wifi GUI test skill
-    def show_confirmation_status(self, text="", override_idle=False):
+    def show_confirmation_status(self, text="", override_idle=False,
+                                 override_animations=False):
         self.clear()
         self["icon"] = resolve_ovos_resource_file("ui/icons/check-circle.svg")
         self["label"] = text
         self["bgColor"] = "#40DBB0"
-        self.show_page("SYSTEM_status.qml", override_idle=override_idle)
+        self.show_page("SYSTEM_status.qml", override_idle=override_idle,
+                       override_animations=override_animations)
 
-    def show_error_status(self, text="", override_idle=False):
+    def show_error_status(self, text="", override_idle=False,
+                          override_animations=False):
         self.clear()
         self["icon"] = resolve_ovos_resource_file("ui/icons/times-circle.svg")
         self["label"] = text
         self["bgColor"] = "#FF0000"
-        self.show_page("SYSTEM_status.qml", override_idle=override_idle)
+        self.show_page("SYSTEM_status.qml", override_idle=override_idle,
+                       override_animations=override_animations)
 
     # video playback
     # https://github.com/MycroftAI/mycroft-core/pull/2683


### PR DESCRIPTION
adds a new template to the GUI

usage
```python
self.gui.show_confirmation_status("Device Paired", override_idle=True)
self.gui.show_error_status("Pairing Failed", override_idle=True)
```
test with https://github.com/OpenVoiceOS/skill-ovos-pairing/tree/ovos_utils by saying "test pairing"

![image](https://user-images.githubusercontent.com/33701864/103488475-b6e18200-4e04-11eb-87b0-bba998b56760.png)
![image](https://user-images.githubusercontent.com/33701864/103488481-c8c32500-4e04-11eb-93a7-de666793eed6.png)
