### PR TITLE
tweak root location priorities

### DIFF
--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -41,16 +41,19 @@ def find_root_from_sitepackages():
 
 
 def search_mycroft_core_location():
-    """Check known mycroft locations followed by python system locations."""
+    """Check python path (.venv), system packages and finally known mycroft
+    locations."""
+    # if we are in a .venv that should take precedence over everything else
+    if find_root_from_sitepackages():
+        return find_root_from_sitepackages()
+    # if there is a system wide install that should take precedence over
+    # hardcoded locations
+    elif find_root_from_sys_path():
+        return find_root_from_sys_path()
+    # finally look at default locations
     for p in MycroftRootLocations:
         if os.path.isdir(p):
             return p
-
-    if find_root_from_sys_path():
-        return find_root_from_sys_path()
-    elif find_root_from_sitepackages():
-        return find_root_from_sitepackages()
-
     return None
 
 


### PR DESCRIPTION
this reorders the checks to find mycroft root location from #25 

- python path first, this should account for active .venvs
- system wide installs
- default known default paths

does this ordering make sense?