### PR TITLE
feat/settingsmeta_gen

### DIFF
--- a/examples/private_settings.py
+++ b/examples/private_settings.py
@@ -1,0 +1,8 @@
+from ovos_utils.skills.settings import PrivateSettings
+
+
+with PrivateSettings("testskill.jarbasai") as settings:
+    print(settings.path)  # ~/.cache/json_database/testskill.jarbasai.json
+    settings["key"] = "value"
+    # auto saved when leaving "with" context
+    # you can also manually call settings.store() if not using "with" context

--- a/examples/private_settings.py
+++ b/examples/private_settings.py
@@ -12,7 +12,7 @@ with PrivateSettings("testskill.jarbasai") as settings:
                                              'name': 'key',
                                              'type': 'text',
                                              'value': 'value'}],
-                                 'name': 'Skill Settings'}]}}
+                                 'name': 'testskill.jarbasai'}]}}
     """
 
     # auto saved when leaving "with" context

--- a/examples/private_settings.py
+++ b/examples/private_settings.py
@@ -4,5 +4,16 @@ from ovos_utils.skills.settings import PrivateSettings
 with PrivateSettings("testskill.jarbasai") as settings:
     print(settings.path)  # ~/.cache/json_database/testskill.jarbasai.json
     settings["key"] = "value"
+
+    meta = settings.settingsmeta
+    # can be used for displaying in GUI
+    """
+    {'skillMetadata': {'sections': [{'fields': [{'label': 'Key',
+                                             'name': 'key',
+                                             'type': 'text',
+                                             'value': 'value'}],
+                                 'name': 'Skill Settings'}]}}
+    """
+
     # auto saved when leaving "with" context
     # you can also manually call settings.store() if not using "with" context

--- a/ovos_utils/skills/settings.py
+++ b/ovos_utils/skills/settings.py
@@ -5,25 +5,26 @@ def settings2meta(settings, section_name="Skill Settings"):
     for k, v in settings.items():
         if k.startswith("_"):
             continue
+        label = k.replace("-", " ").replace("_", " ").title()
         if isinstance(v, bool):
             fields.append({
                 "name": k,
                 "type": "checkbox",
-                "label": k,
+                "label": label,
                 "value": str(v).lower()
             })
         if isinstance(v, str):
             fields.append({
                 "name": k,
                 "type": "text",
-                "label": k,
+                "label": label,
                 "value": v
             })
         if isinstance(v, int):
             fields.append({
                 "name": k,
                 "type": "number",
-                "label": k,
+                "label": label,
                 "value": str(v)
             })
     return {

--- a/ovos_utils/skills/settings.py
+++ b/ovos_utils/skills/settings.py
@@ -1,0 +1,38 @@
+def settings2meta(settings, section_name="Skill Settings"):
+    """ generates basic settingsmeta """
+    fields = []
+
+    for k, v in settings.items():
+        if k.startswith("_"):
+            continue
+        if isinstance(v, bool):
+            fields.append({
+                "name": k,
+                "type": "checkbox",
+                "label": k,
+                "value": str(v).lower()
+            })
+        if isinstance(v, str):
+            fields.append({
+                "name": k,
+                "type": "text",
+                "label": k,
+                "value": v
+            })
+        if isinstance(v, int):
+            fields.append({
+                "name": k,
+                "type": "number",
+                "label": k,
+                "value": str(v)
+            })
+    return {
+        "skillMetadata": {
+            "sections": [
+                {
+                    "name": section_name,
+                    "fields": fields
+                }
+            ]
+        }
+    }

--- a/ovos_utils/skills/settings.py
+++ b/ovos_utils/skills/settings.py
@@ -1,3 +1,6 @@
+from json_database import JsonStorageXDG
+
+
 def settings2meta(settings, section_name="Skill Settings"):
     """ generates basic settingsmeta """
     fields = []
@@ -37,3 +40,12 @@ def settings2meta(settings, section_name="Skill Settings"):
             ]
         }
     }
+
+
+class PrivateSettings(JsonStorageXDG):
+    def __init__(self, skill_id):
+        super(PrivateSettings, self).__init__(skill_id)
+
+    @property
+    def settingsmeta(self):
+        return settings2meta(self)

--- a/ovos_utils/skills/settings.py
+++ b/ovos_utils/skills/settings.py
@@ -48,4 +48,4 @@ class PrivateSettings(JsonStorageXDG):
 
     @property
     def settingsmeta(self):
-        return settings2meta(self)
+        return settings2meta(self, self.name)

--- a/ovos_utils/waiting_for_mycroft/base_skill.py
+++ b/ovos_utils/waiting_for_mycroft/base_skill.py
@@ -11,6 +11,7 @@ from ovos_utils.log import LOG
 from ovos_utils import camel_case_split, get_handler_name, \
     create_killable_daemon, ensure_mycroft_import
 from ovos_utils.messagebus import Message
+from ovos_utils.skills.settings import PrivateSettings
 import threading
 from inspect import signature
 from functools import wraps
@@ -136,6 +137,7 @@ class MycroftSkill(_MycroftSkill):
         self.gui = SkillGUI(self)  # pull/2683
         self._threads = []
         self._original_converse = self.converse
+        self.private_settings = None  # TODO make a PR in mycroft-core ?
 
     # TODO PR for core - stops skill executing gracefully
     # this method can probably use a better refactor, we are only changing one
@@ -405,6 +407,8 @@ class MycroftSkill(_MycroftSkill):
             ConverseTracker.connect_bus(self.bus)  # pull/1468
             self.add_event("converse.skill.deactivated",
                            self._deactivate_skill)
+            # here to ensure self.skill_id is populated
+            self.private_settings = PrivateSettings(self.skill_id)
 
     # https://github.com/MycroftAI/mycroft-core/pull/2675
     def voc_match(self, utt, voc_filename, lang=None, exact=False):


### PR DESCRIPTION
Adds 2 new utilities, a method to auto generate the `settingsmeta.json`, useful for bootstraping when starting a skill, and a `PrivateSettings` class for skills to use, this applied as a patch for skills importing the base class from ovos_utils

This allows basic usage of https://github.com/MycroftAI/mycroft-core/pull/2698 even if skills dont provide `settingsmeta.json`

I almost never provide the settingsmeta for privacy + buggy behaviour reasons, with this my skills will still provide a UI without mycroft messing things up

### Usage

#### settings2meta

Here is an example from the video collection skill template

```python
s = {"max_videos": 500, "min_duration": -1, "max_duration": -1,
     "shuffle_menu": False, "filter_live": False, "filter_date": False,
     "min_score": 40, "match_description": False, "match_tags": True,
     "match_title": True, "search_depth": 500,
     "__mycroft_skill_firstrun": False, "filter_trailers": True,
     "filter_behind_scenes": True}
    
meta = settings2meta(s)
```

outputs
	  
```
{'skillMetadata': {'sections': [{'fields': [{'label': 'Max Videos',
                                             'name': 'max_videos',
                                             'type': 'number',
                                             'value': '500'},
	                                        (...)
                                            {'label': 'Search Depth',
                                             'name': 'search_depth',
                                             'type': 'number',
                                             'value': '500'},
                                            {'label': 'Filter Behind Scenes',
                                             'name': 'filter_behind_scenes',
                                             'type': 'number',
                                             'value': 'True'}],
                                   'name': 'Skill Settings'}]}}
```

#### PrivateSettings

can be used standalone

```python
from ovos_utils.skills.settings import PrivateSettings


with PrivateSettings("testskill.jarbasai") as settings:
    print(settings.path)  # ~/.cache/json_database/testskill.jarbasai.json
    settings["key"] = "value"

    meta = settings.settingsmeta
    # can be used for displaying in GUI
    """
    {'skillMetadata': {'sections': [{'fields': [{'label': 'Key',
                                             'name': 'key',
                                             'type': 'text',
                                             'value': 'value'}],
                                     'name': 'testskill.jarbasai'}]}}
    """

    # auto saved when leaving "with" context
    # you can also manually call settings.store() if not using "with" context
```

or inside a skill

```python
from ovos_utils.waiting_for_mycroft.base_skill import MycroftSkill


class MySkill(MycroftSkill):
    """ 
    this is a skill with more functionality than base mycroft-core, 
	self.private_settings is NOT available in the __init__ method, 
    self.private_settings is NOT available if MycroftSkill is imported from mycroft-core instead of ovos_utils 
    """
    
	def initialize(self):
	    # reading data
	    my_secret = self.private_settings.get("secret")
	    # saving data
	    self.private_settings["password"] = "password1"
	    self.private_settings.store()
	    
```