### PR TITLE
translation cleanup

### DIFF
--- a/examples/translation_utils.py
+++ b/examples/translation_utils.py
@@ -1,22 +1,20 @@
 from ovos_utils.lang import detect_lang, translate_text
 
 # detecting language
-assert detect_lang("olá eu chamo-me joaquim") == "pt"
+detect_lang("olá eu chamo-me joaquim")  # "pt"
+detect_lang("olá eu chamo-me joaquim", return_dict=True)
+"""{'confidence': 0.9999939001351439, 'language': 'pt'}"""
 
-assert detect_lang("olá eu chamo-me joaquim", return_dict=True) == \
-       {'confidence': 0.9999939001351439, 'language': 'pt'}
-
-assert detect_lang("hello world") == "en"
-
-assert detect_lang(
-    "This piece of text is in English. Този текст е на Български.",
-    return_dict=True) == {'confidence': 0.28571342657428966, 'language': 'en'}
+detect_lang("hello world")  # "en"
+detect_lang("This piece of text is in English. Този текст е на Български.", return_dict=True)
+"""{'confidence': 0.28571342657428966, 'language': 'en'}"""
 
 # translating text
+#  - source lang will be auto detected using utils above
+#  - default target language is english
+translate_text("olá eu chamo-me joaquim")
+"""Hello I call myself joaquim"""
 
-## source lang will be auto detected using utils above
-## default target language is english
-assert translate_text("olá eu chamo-me joaquim") == "Hello I call myself joaquim"
-
-## you should specify source lang whenever possible to save 1 api call
-assert translate_text("olá eu chamo-me joaquim", source_lang="pt") == "Hello I call myself joaquim"
+#  - you should specify source lang whenever possible to save 1 api call
+translate_text("olá eu chamo-me joaquim", source_lang="pt", lang="es")
+"""Hola, me llamo Joaquim"""

--- a/examples/translation_utils.py
+++ b/examples/translation_utils.py
@@ -1,0 +1,22 @@
+from ovos_utils.lang import detect_lang, translate_text
+
+# detecting language
+assert detect_lang("olá eu chamo-me joaquim") == "pt"
+
+assert detect_lang("olá eu chamo-me joaquim", return_dict=True) == \
+       {'confidence': 0.9999939001351439, 'language': 'pt'}
+
+assert detect_lang("hello world") == "en"
+
+assert detect_lang(
+    "This piece of text is in English. Този текст е на Български.",
+    return_dict=True) == {'confidence': 0.28571342657428966, 'language': 'en'}
+
+# translating text
+
+## source lang will be auto detected using utils above
+## default target language is english
+assert translate_text("olá eu chamo-me joaquim") == "Hello I call myself joaquim"
+
+## you should specify source lang whenever possible to save 1 api call
+assert translate_text("olá eu chamo-me joaquim", source_lang="pt") == "Hello I call myself joaquim"

--- a/ovos_utils/lang/__init__.py
+++ b/ovos_utils/lang/__init__.py
@@ -1,5 +1,7 @@
 from os.path import expanduser, isdir, dirname, join
 from os import system, makedirs, listdir
+from ovos_utils.lang.detect import detect_lang
+from ovos_utils.lang.translate import translate_text
 
 
 def get_tts(sentence, lang="en-us", mp3_file="/tmp/google_tx_tts.mp3"):

--- a/ovos_utils/lang/detect.py
+++ b/ovos_utils/lang/detect.py
@@ -1,136 +1,25 @@
-from ovos_utils.log import LOG
-
-try:
-    from google_trans_new import google_translator
-except ImportError:
-    google_translator = None
-
-try:
-    import pycld2 as cld2
-except ImportError:
-    cld2 = None
-
-try:
-    import cld3
-except ImportError:
-    cld3 = None
+import requests
 
 
-def code_to_name(lang_code):
-    lang_code = lang_code.lower()
-    for name, code in cld2.LANGUAGES:
-        if code == lang_code:
-            return name.lower().capitalize()
-    lang_code = lang_code.split("-")[0]
-    for name, code in cld2.LANGUAGES:
-        if code == lang_code:
-            return name.lower().capitalize()
-    return "Unknown"
-
-
-def detect_lang_naive(text, return_multiple=False, return_dict=False,
-                      hint_language=None, filter_unreliable=False):
-    """
-
-    :param text:
-    :param return_multiple bool if True return a list of all languages detected, else the top language
-    :param return_dict: bool  if True returns all data, E.g.,  pt -> {'lang': 'Portuguese', 'lang_code': 'pt', 'conf': 0.96}
-    :param hint_language: str  E.g., 'ITALIAN' or 'it' boosts Italian
-    :return:
-    """
-    if cld2 is None:
-        LOG.debug("run pip install pycld2")
-        raise ImportError("pycld2 not installed")
-    isReliable, textBytesFound, details = cld2.detect(text, hintLanguage=hint_language)
-    languages = []
-
-    # filter unreliable predictions
-    if not isReliable and filter_unreliable:
-        return None
-
-    # select first language only
-    if not return_multiple:
-        details = [details[0]]
-
-    for name, code, score, _ in details:
-        if code == "un":
-            continue
-        if return_dict:
-            languages.append({"lang": name.lower().capitalize(), "lang_code": code, "conf": score / 100})
-        else:
-            languages.append(code)
-
-    # return top language only
-    if not return_multiple:
-        if not len(languages):
-            return None
-        return languages[0]
-    return languages
-
-
-def detect_lang_neural(text, return_multiple=False, return_dict=False,
-                       hint_language=None, filter_unreliable=False):
-    if cld3 is None:
-        LOG.debug("run pip install pycld3")
-        raise ImportError("pycld3 not installed")
-    languages = []
-    if return_multiple or hint_language:
-        preds = sorted(cld3.get_frequent_languages(text, num_langs=5), key=lambda i: i.probability, reverse=True)
-        for pred in preds:
-            if filter_unreliable and not pred.is_reliable:
-                continue
-            if return_dict:
-                languages += [{"lang_code": pred.language,
-                               "lang": code_to_name(pred.language),
-                               "conf": pred.probability}]
-            else:
-                languages.append(pred.language)
-
-            if hint_language and hint_language == pred.language:
-                languages = [languages[-1]]
-                break
-    else:
-        pred = cld3.get_language(text)
-        if filter_unreliable and not pred.is_reliable:
-            pass
-        elif return_dict:
-            languages = [{"lang_code": pred.language,
-                          "lang": code_to_name(pred.language),
-                          "conf": pred.probability}]
-        else:
-            languages = [pred.language]
-
-    # return top language only
-    if not return_multiple:
-        if not len(languages):
-            return None
-        return languages[0]
-    return languages
-
-
-def detect_lang_google(text, return_dict=False):
-    if google_translator is None:
-        LOG.debug("run pip install google_trans_new")
-        raise ImportError("google_trans_new not installed")
-    translator = google_translator()
-    tx = translator.detect(text)
+def detect_lang(text, return_dict=False, key=None,
+                url="https://libretranslate.com/detect"):
+    """host it yourself https://github.com/uav4geo/LibreTranslate"""
+    params = {"q": text}
+    if key:
+        params["api_key"] = key
+    res = requests.post(url, params=params).json()
     if return_dict:
-        return {"lang_code": tx[0], "lang": tx[1]}
-    return tx[0]
-
-
-def detect_lang(text, return_dict=False):
-    if cld2 is not None:
-        return detect_lang_naive(text, return_dict=return_dict)
-    return detect_lang_google(text, return_dict=return_dict)
+        return res[0]
+    return res[0]["language"]
 
 
 if __name__ == "__main__":
-    assert detect_lang_google("olá eu chamo-me joaquim") == "pt"
-    assert detect_lang_naive("olá eu chamo-me joaquim", return_dict=True) == \
-           {'lang': 'Portuguese', 'lang_code': 'pt', 'conf': 0.96}
+    assert detect_lang("olá eu chamo-me joaquim") == "pt"
 
-    assert detect_lang_naive("hello world") == "en"
+    assert detect_lang("olá eu chamo-me joaquim", return_dict=True) == \
+           {'confidence': 0.9999939001351439, 'language': 'pt'}
+
+    assert detect_lang("hello world") == "en"
 
     fr_en = """\
     France is the largest country in Western Europe and the third-largest in Europe as a whole.
@@ -141,27 +30,7 @@ if __name__ == "__main__":
     Motoring events began soon after the construction of the first successful gasoline-fueled automobiles.
     The quick brown fox jumped over the lazy dog."""
 
-    assert detect_lang_naive(fr_en) == "fr"
-    assert detect_lang_naive(fr_en, return_multiple=True) == ['fr', 'en']
+    assert detect_lang(fr_en) == "fr"
 
-    assert detect_lang_naive(fr_en, hint_language="en", return_dict=True) == \
-           {'lang': 'English', 'lang_code': 'en', 'conf': 0.6}  # boost english score
-
-    assert detect_lang_naive(fr_en, return_dict=True, return_multiple=True)[1][
-               "conf"] == 0.41  # compare conf with non boosted result
-
-    assert detect_lang_naive(fr_en, return_dict=True) == \
-           {'lang': 'French', 'lang_code': 'fr', 'conf': 0.58}
-    assert detect_lang_neural(fr_en, return_dict=True) == \
-           {'lang_code': 'fr', 'lang': 'French', 'conf': 0.9675191640853882}
-
-    assert detect_lang_neural("This piece of text is in English. Този текст е на Български.",
-                              return_dict=True,
-                              return_multiple=True) == [
-        {'lang_code': 'en', 'lang': 'English', 'conf': 0.9999790191650391},
-        {'lang_code': 'bg', 'lang': 'Bulgarian', 'conf': 0.9173873066902161}
-        ]
-
-    assert detect_lang_neural("This piece of text is in English. Този текст е на Български.") == "en"
-    assert detect_lang_neural("This piece of text is in English. Този текст е на Български.", return_dict=True, hint_language="bg") == \
-           {'lang_code': 'bg', 'lang': 'Bulgarian', 'conf': 0.9173873066902161} # Boost bulgarian
+    assert detect_lang("This piece of text is in English. Този текст е на Български.",
+                              return_dict=True) == {'confidence': 0.28571342657428966, 'language': 'en'}

--- a/ovos_utils/lang/translate.py
+++ b/ovos_utils/lang/translate.py
@@ -1,75 +1,15 @@
-from ovos_utils.sound import play_mp3
 from ovos_utils.lang.detect import detect_lang
-from ovos_utils.lang import get_tts
-from ovos_utils.log import LOG
-
 import requests
 
-try:
-    from google_trans_new import google_translator
-except ImportError:
-    google_translator = None
 
-import logging
-
-logging.getLogger("hpack").setLevel("ERROR")
-logging.getLogger("chardet").setLevel("ERROR")
-
-
-def translate_text(text, lang="en-us", source_lang=None):
-    tx = None
-    if source_lang:
-        tx = translate_libretranslate(text, lang, source_lang)
-    if not tx:
-        LOG.warning("Falling back to google translate")
-        return translate_google(text, lang, source_lang)
-    return tx
-
-
-def translate_to_mp3(sentence, lang="en-us", mp3_file=None):
-    if detect_lang(sentence) != lang.split("-")[0]:
-        sentence = translate_text(sentence, lang)
-    return get_tts(sentence, lang, mp3_file)
-
-
-def say_in_language(sentence, lang="en-us", mp3_file=None):
-    mp3_file = translate_to_mp3(sentence, lang, mp3_file)
-    play_mp3(mp3_file)
-    return sentence
-
-
-def translate_apertium(text, lang="en-us", source_lang=None):
-    lang_pair = lang
-    if source_lang:
-        lang_pair = source_lang + "|" + lang
-    r = requests.get("https://www.apertium.org/apy/translate",
-                     params={"q": text, "langpair": lang_pair}).json()
-    if r.get("status", "") == "error":
-        LOG.error(r["explanation"])
-        return None
-    return r["responseData"]["translatedText"]
-
-
-def translate_google(text, lang="en-us", source_lang=None):
-    if google_translator is None:
-        LOG.debug("run pip install google_trans_new")
-        raise ImportError("google_trans_new not installed")
-    translator = google_translator()
+def translate_text(text, lang="en-us", source_lang=None,
+             url="https://libretranslate.com/translate"):
+    """host it yourself https://github.com/uav4geo/LibreTranslate"""
     lang = lang.split("-")[0]
     if source_lang:
         source_lang = source_lang.split("-")[0]
-        tx = translator.translate(text, lang_src=source_lang, lang_tgt=lang)
     else:
-        tx = translator.translate(text, lang_tgt=lang)
-    return tx.strip()
-
-
-def translate_libretranslate(text, lang="en-us", source_lang=None,
-                             url="https://libretranslate.com/translate"):
-    # host it yourself https://github.com/uav4geo/LibreTranslate
-    lang = lang.split("-")[0]
-    if source_lang:
-        source_lang = source_lang.split("-")[0]
+        source_lang = detect_lang(text)
     r = requests.post(url, params={"q": text,
                                    "source": source_lang,
                                    "target": lang}).json()


### PR DESCRIPTION
breaking change, removes the mess that the translation utilities were, returned data is different and many methods are missing

apertium essentially only worked for spanish, google is not privacy respecting

libretranslate is FOSS, can be self hosted, provides a demo key, supports many languages, and is accurate, this is now the default and only engine

closes #2

### Usage

```python
from ovos_utils.lang import detect_lang

# detecting language
detect_lang("olá eu chamo-me joaquim") # "pt"
detect_lang("olá eu chamo-me joaquim", return_dict=True) 
# {'confidence': 0.9999939001351439, 'language': 'pt'}
detect_lang("hello world") # "en"
detect_lang("This piece of text is in English. Този текст е на Български.", return_dict=True) 
# {'confidence': 0.28571342657428966, 'language': 'en'}
```

```python
from ovos_utils.lang import translate_text

## source lang will be auto detected using utils above
## default target language is english
translate_text("olá eu chamo-me joaquim") # "Hello I call myself joaquim"

## you should specify source lang whenever possible to save 1 api call
translate_text("olá eu chamo-me joaquim", source_lang="pt", lang="es") # "Hola, me llamo Joaquim"
```