### PR TITLE
core fingerprinting

### DIFF
--- a/ovos_utils/enclosure/__init__.py
+++ b/ovos_utils/enclosure/__init__.py
@@ -1,7 +1,6 @@
 from ovos_utils.system import MycroftRootLocations
-from ovos_utils.log import LOG
 from enum import Enum
-from os.path import exists, join
+from os.path import exists
 
 
 class MycroftEnclosures(str, Enum):
@@ -11,6 +10,7 @@ class MycroftEnclosures(str, Enum):
     OLD_MARK1 = "mycroft_mark_1(old)"
     MARK1 = "mycroft_mark_1"
     MARK2 = "mycroft_mark_2"
+    GENERIC = "generic"  # default value for HolmesV derivatives
     OTHER = "unknown"
 
 
@@ -54,5 +54,7 @@ def detect_enclosure():
         return MycroftEnclosures.MARK2
     elif fingerprint == "picroft":
         return MycroftEnclosures.PICROFT
+    elif fingerprint == "generic":
+        return MycroftEnclosures.GENERIC
 
     return MycroftEnclosures.OTHER

--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -7,6 +7,7 @@ import sysconfig
 from enum import Enum
 import platform
 import socket
+from xdg import BaseDirectory as XDG
 from os.path import expanduser, exists, join, isfile
 
 
@@ -191,6 +192,7 @@ def get_platform_fingerprint():
         "is_gui_installed": is_installed("mycroft-gui-app"),
         "is_vlc_installed": is_installed("vlc"),
         "pulseaudio_running": is_process_running("pulseaudio"),
+        "core_supports_xdg": core_supports_xdg(),
         "core_version": {
             "version_str": get_mycroft_version(),
             "is_chatterbox_core": is_chatterbox_core(),
@@ -264,3 +266,13 @@ def is_holmes():
 
 def is_ovos():
     return "OpenVoiceOS" in (get_mycroft_version() or "")
+
+
+def core_supports_xdg():
+    if any((is_holmes(), is_ovos(), is_neon_core(), is_chatterbox_core())):
+        return True
+    # mycroft-core does not support XDG as of 10 may 2021
+    # however there are patched versions out there, eg, alpine package
+    # check if the .conf exists in new location
+    # TODO deprecate
+    return isfile(join(XDG.save_config_path('mycroft'), 'mycroft.conf'))

--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -246,7 +246,7 @@ def is_chatterbox_core():
 
 def is_neon_core():
     try:
-        import chatterbox
+        import neon_core
         return True
     except ImportError:
         return False

--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -22,6 +22,37 @@ class MycroftRootLocations(str, Enum):
     HOME = expanduser("~/mycroft-core")  # git clones
 
 
+# system utils
+def ntp_sync():
+    # Force the system clock to synchronize with internet time servers
+    subprocess.call('service ntp stop', shell=True)
+    subprocess.call('ntpd -gq', shell=True)
+    subprocess.call('service ntp start', shell=True)
+
+
+def system_shutdown():
+    # Turn the system completely off (with no option to inhibit it)
+    subprocess.call('sudo systemctl poweroff -i', shell=True)
+
+
+def system_reboot():
+    # Shut down and restart the system
+    subprocess.call('sudo systemctl reboot -i', shell=True)
+
+
+def ssh_enable():
+    # Permanently allow SSH access
+    subprocess.call('sudo systemctl enable ssh.service', shell=True)
+    subprocess.call('sudo systemctl start ssh.service', shell=True)
+
+
+def ssh_disable():
+    # Permanently block SSH access from the outside
+    subprocess.call('sudo systemctl stop ssh.service', shell=True)
+    subprocess.call('sudo systemctl disable ssh.service', shell=True)
+
+
+# platform fingerprinting
 def find_root_from_sys_path():
     """Find mycroft root folder from sys.path, eg. venv site-packages."""
     for p in [path for path in sys.path if path != '']:
@@ -165,7 +196,6 @@ def get_platform_fingerprint():
         "pulseaudio_running": is_process_running("pulseaudio")
     }
 
-
 def get_mycroft_version():
     try:
         from mycroft.version import CORE_VERSION_STR
@@ -195,30 +225,30 @@ def get_mycroft_version():
         return None
 
 
-def ntp_sync():
-    # Force the system clock to synchronize with internet time servers
-    subprocess.call('service ntp stop', shell=True)
-    subprocess.call('ntpd -gq', shell=True)
-    subprocess.call('service ntp start', shell=True)
+def is_chatterbox_core():
+    try:
+        import chatterbox
+        return True
+    except ImportError:
+        return False
 
 
-def system_shutdown():
-    # Turn the system completely off (with no option to inhibit it)
-    subprocess.call('sudo systemctl poweroff -i', shell=True)
+def is_neon_core():
+    try:
+        import chatterbox
+        return True
+    except ImportError:
+        return False
 
 
-def system_reboot():
-    # Shut down and restart the system
-    subprocess.call('sudo systemctl reboot -i', shell=True)
+def is_mycroft_core():
+    try:
+        import mycroft
+        return True
+    except ImportError:
+        return False
 
 
-def ssh_enable():
-    # Permanently allow SSH access
-    subprocess.call('sudo systemctl enable ssh.service', shell=True)
-    subprocess.call('sudo systemctl start ssh.service', shell=True)
+def is_holmesV():
+    return "HolmvesV" in ""
 
-
-def ssh_disable():
-    # Permanently block SSH access from the outside
-    subprocess.call('sudo systemctl stop ssh.service', shell=True)
-    subprocess.call('sudo systemctl disable ssh.service', shell=True)

--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-import sys
 import os
 import subprocess
 import re

--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -189,19 +189,30 @@ def get_platform_fingerprint():
         "release": platform.release(),
         "desktop_env": get_desktop_environment(),
         "mycroft_core_location": search_mycroft_core_location(),
-        "mycroft_core_version": get_mycroft_version(),
         "can_display": has_screen(),
         "is_gui_installed": is_installed("mycroft-gui-app"),
         "is_vlc_installed": is_installed("vlc"),
-        "pulseaudio_running": is_process_running("pulseaudio")
+        "pulseaudio_running": is_process_running("pulseaudio"),
+        "core_version": {
+            "version_str": get_mycroft_version(),
+            "is_chatterbox_core": is_chatterbox_core(),
+            "is_neon_core": is_neon_core(),
+            "is_holmes": is_holmes(),
+            "is_ovos": is_ovos(),
+            "is_mycroft_core": is_mycroft_core()
+        }
     }
+
 
 def get_mycroft_version():
     try:
         from mycroft.version import CORE_VERSION_STR
         return CORE_VERSION_STR
     except:
-        root = search_mycroft_core_location()
+        pass
+
+    root = search_mycroft_core_location()
+    if root:
         version_file = join(root, "version", "__init__.py")
         if not isfile(version_file):
             version_file = join(root, "mycroft", "version", "__init__.py")
@@ -249,6 +260,9 @@ def is_mycroft_core():
         return False
 
 
-def is_holmesV():
-    return "HolmvesV" in ""
+def is_holmes():
+    return "HolmesV" in (get_mycroft_version() or "")
 
+
+def is_ovos():
+    return "OpenVoiceOS" in (get_mycroft_version() or "")


### PR DESCRIPTION
- util to get mycroft version string
- util to detect xdg support in core (lots of community projects using XDG patch)
- utils to detect different cores (chatterbox/neon/holmes/neon)
- use new utils in platform_fingerprint

```python
"core_supports_xdg": core_supports_xdg(),
"core_version": {
    "version_str": get_mycroft_version(),
    "is_chatterbox_core": is_chatterbox_core(),
    "is_neon_core": is_neon_core(),
    "is_holmes": is_holmes(),
    "is_ovos": is_ovos(),
    "is_mycroft_core": is_mycroft_core()
}
```