### PR TITLE
Downgrade missing Mycroft config log

### DIFF
--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -256,7 +256,7 @@ class MycroftDefaultConfig(ReadOnlyConfig):
         path = find_default_config()
         super().__init__(path)
         if not self.path or not isfile(self.path):
-            LOG.error("mycroft root path not found, could not load default "
+            LOG.info("mycroft root path not found, could not load default "
                       ".conf")
 
     def set_root_config_path(self, root_config):

--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -256,7 +256,7 @@ class MycroftDefaultConfig(ReadOnlyConfig):
         path = find_default_config()
         super().__init__(path)
         if not self.path or not isfile(self.path):
-            LOG.info("mycroft root path not found, could not load default "
+            LOG.debug("mycroft root path not found, could not load default "
                       ".conf")
 
     def set_root_config_path(self, root_config):


### PR DESCRIPTION
Changes the log from ERROR to DEBUG when no Mycroft configuration is found. This log occurs regularly under non-Mycroft cores, even though those cores may read their own config paths